### PR TITLE
Add scalardb

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ A curated list of awesome [Apache Cassandra](http://cassandra.apache.org/) packa
 - [Spring Data for Apache Cassandra](http://projects.spring.io/spring-data-cassandra/) -  Spring Data for Apache Cassandra offers a familiar interface to those who have used other Spring Data modules in the past.
 - [gocql](https://github.com/gocql/gocql) - Package gocql implements a fast and robust Cassandra client for the Go programming language.
 - OLD - [Netflix Astyanax](https://github.com/Netflix/astyanax): Astyanax is a high level Java client for Apache Cassandra, based on Thrift protocol. Not maintained.
+- [Scalar DB](https://github.com/scalar-labs/scalardb) - Transaction library for Cassandra
 
 ### Tools
 - [CassandraCAS](https://github.com/Datomic/CassandraCAS) - A compare-and-swap tool for Cassandra created by Datomic.


### PR DESCRIPTION
I added one library called Scalar DB. This achieves ACID-compliant transaction on Cassandra without changing Cassandra itself. 