### PR TITLE
Update README.md for link corrections and 1 new article

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ This is a curated list of awesome [Cassandra](https://github.com/apache/cassandr
 
 ### Cassandra History
 
+
+- [IDG: 10 Years of Apache Cassandra](https://www.idgconnect.com/article/3580401/10-years-of-apache-cassandra.html) - Retrospective discussing the first 10 years of Cassandra's history.
 - [ZDNet: Cassandra Turns 10](https://www.zdnet.com/article/apache-cassandra-turns-10/) - Highlights of the growth of Cassandra over it's first 10 years.
 
 ### Cassandra Use Cases
@@ -123,7 +125,7 @@ This is a curated list of awesome [Cassandra](https://github.com/apache/cassandr
 - [Cassandra Query Language: CQL vs SQL](https://medium.com/@alexbmeng/cassandra-query-language-cql-vs-sql-7f6ed7706b4c) - Blog post documenting similarities and differences between CQL and SQL.
 <!-- - [MySQL to C*](http://planetcassandra.org/mysql-to-cassandra-migration/) - MySQL to Cassandra migration guide.  !This is just redirecting to https://www.datastax.com/dev -->
 <!-- - [Cassandra and Relational database schema comparison – Query vs relationship modeling](https://blog.rdx.com/cassandra-and-relational-database-schema-comparison-query-vs-relationship-modeling/) - Lacking security certificate as of 4/12/2021 @ 8:50 am MST -->
-<!-- - [Real-Time Replication from MySQL to Cassandra](https://mcbguru.blog/2014/02/27/real-time-replication-from-mysql-to-cassandra/) - Website is down as of 4/12/2021 @ 8:47 am MST -->
+- [Real-Time Replication from MySQL to Cassandra](https://planet.mcb.guru/?p=6890) - Demonstration of migrating data from MySQL to Cassandra. 
 
 ### Cassandra Data Modeling
 
@@ -405,7 +407,6 @@ This is a curated list of awesome [Cassandra](https://github.com/apache/cassandr
 - [DbSchema - Cassandra Designer](https://dbschema.com/database-designer/Cassandra.html) - DbSchema: Cassandra Diagram Designer & GUI Admin Tool which can do Cassandra amongst other databases.
 - [DBeaver - Free Universal Database Tool](https://dbeaver.io/) - Third party tool for dealing with all sorts of databases including Cassandra.
 - [RazorSQL - Multi DB Manager Tool](https://razorsql.com/) - Multi-db tool for Linux, Mac, and Windows that works with Cassandra.
-- [KDM - The Kashlev Data Modeler](http://kdm-portal.weebly.com/) - Automated big data modeling tool for Cassandra.
 - [Cassandra Reaper](http://cassandra-reaper.io/) - Automated repairs for Cassandra. Supports all versions.
 - [cstar perf](https://github.com/datastax/cstar_perf) - Cassandra performance testing platform.
 - [Spark Cassandra Stress](https://github.com/datastax/spark-cassandra-stress) - Tool for testing the DataStax Spark Connector against Cassandra or DSE.
@@ -503,7 +504,6 @@ This is a curated list of awesome [Cassandra](https://github.com/apache/cassandr
 - [Cassandra Developers Mailing List](http://www.mail-archive.com/dev@cassandra.apache.org/)
 - [Cassandra Commits Mailing List](http://www.mail-archive.com/commits@cassandra.apache.org/)
 - [Apache Software Foundation Slack](https://s.apache.org/slack-invite) - The #cassandra and #cassandra-dev channels are official slack channels migrating from IRC.
-- [Datastax Academy Slack](https://academy.datastax.com/slack)
 - [Cassandra Slack](https://cassandra-slack.herokuapp.com/)
 - [Stack Overflow: Cassandra](https://stackoverflow.com/questions/tagged/cassandra)
 - [Stack Overflow: cql](https://stackoverflow.com/questions/tagged/cql)


### PR DESCRIPTION
Removed "Datastax Academy Slack" as they no longer host a slack channel
Added correct link for formerly erased "IDG: 10 years of Apache Cassandra" article with description: "Retrospective discussing the first 10 years of Cassandra's history"
Removed KDM from ### Tools
Added back "Real-Time Replication from MySQL to Cassandra" to ### Cassandra from Relational with description: "Demonstration of migrating data from MySQL to Cassandra"